### PR TITLE
Align entities with redesigned database

### DIFF
--- a/src/main/java/se499/kayaanbackend/entity/ContentInformation.java
+++ b/src/main/java/se499/kayaanbackend/entity/ContentInformation.java
@@ -1,0 +1,59 @@
+package se499.kayaanbackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "content_information")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ContentInformation {
+
+    public enum ContentType {
+        QUIZ, FLASHCARD, NOTE
+    }
+
+    public enum Difficulty {
+        EASY, MEDIUM, HARD
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "contentInfoID")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "contentType", nullable = false)
+    private ContentType contentType;
+
+    @Column(name = "contentSubject", nullable = false)
+    private String contentSubject;
+
+    @Column(name = "contentTitle", nullable = false)
+    private String contentTitle;
+
+    @Column(name = "tag")
+    private String tag;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "difficulty", nullable = false)
+    private Difficulty difficulty;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userID", nullable = false)
+    private se499.kayaanbackend.security.user.User user;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/se499/kayaanbackend/entity/Flashcard.java
+++ b/src/main/java/se499/kayaanbackend/entity/Flashcard.java
@@ -2,9 +2,12 @@ package se499.kayaanbackend.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import java.util.List;
+
+import se499.kayaanbackend.entity.FlashcardImage;
 
 @Entity
-@Table(name = "flashcards")
+@Table(name = "flashcard_info")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -13,22 +16,28 @@ import lombok.*;
 public class Flashcard {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "flashcardID")
     private Long id;
 
-    @Column(nullable = false)
-    private String createdByUsername;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contentInfoID", nullable = false)
+    private ContentInformation contentInformation;
 
-    @Column(nullable = false)
-    private String frontText;   // e.g. “Define polymorphism”
+    @Column(name = "flashcardDetail", nullable = false, columnDefinition = "TEXT")
+    private String frontText;
 
-    @Column(nullable = false)
-    private String backText;    // e.g. “Polymorphism is ...”
+    @Column(name = "flashcardAnswer", nullable = false, columnDefinition = "TEXT")
+    private String backText;
 
-    private String subject;
-    private String difficulty;
+    @OneToMany(mappedBy = "flashcard", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FlashcardImage> images;
 
-    @ElementCollection
-    @CollectionTable(name = "flashcard_tags", joinColumns = @JoinColumn(name = "flashcard_id"))
-    @Column(name = "tag")
-    private java.util.List<String> tags;
+    @Column(name = "created_at")
+    private java.time.LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private java.time.LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deletedAt;
 }

--- a/src/main/java/se499/kayaanbackend/entity/FlashcardImage.java
+++ b/src/main/java/se499/kayaanbackend/entity/FlashcardImage.java
@@ -1,0 +1,36 @@
+package se499.kayaanbackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "flashcard_image")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FlashcardImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "imageID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "flashcardID", nullable = false)
+    private Flashcard flashcard;
+
+    @Column(name = "imageURL", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/se499/kayaanbackend/entity/Note.java
+++ b/src/main/java/se499/kayaanbackend/entity/Note.java
@@ -2,11 +2,12 @@ package se499.kayaanbackend.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-
 import java.util.List;
 
+import se499.kayaanbackend.entity.NoteImage;
+
 @Entity
-@Table(name = "notes")
+@Table(name = "note_information")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -15,25 +16,25 @@ import java.util.List;
 public class Note {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "noteID")
     private Long id;
 
-    @Column(nullable = false)
-    private String createdByUsername;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contentInfoID", nullable = false)
+    private ContentInformation contentInformation;
 
-    @Column(nullable = false)
-    private String title;
-
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(name = "note_text", columnDefinition = "LONGTEXT")
     private String content;
 
-    @Column(nullable = true)
-    private String subject;
+    @OneToMany(mappedBy = "note", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<NoteImage> images;
 
-    @Column(nullable = true)
-    private String difficulty;
+    @Column(name = "created_at")
+    private java.time.LocalDateTime createdAt;
 
-    @ElementCollection
-    @CollectionTable(name = "note_tags", joinColumns = @JoinColumn(name = "note_id"))
-    @Column(name = "tag")
-    private List<String> tags;
+    @Column(name = "updated_at")
+    private java.time.LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deletedAt;
 }

--- a/src/main/java/se499/kayaanbackend/entity/NoteImage.java
+++ b/src/main/java/se499/kayaanbackend/entity/NoteImage.java
@@ -1,0 +1,36 @@
+package se499.kayaanbackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "note_image")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NoteImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "imageID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "noteID", nullable = false)
+    private Note note;
+
+    @Column(name = "imageURL", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/se499/kayaanbackend/entity/Quiz.java
+++ b/src/main/java/se499/kayaanbackend/entity/Quiz.java
@@ -6,8 +6,10 @@ import lombok.*;
 
 import java.util.List;
 
+import se499.kayaanbackend.entity.QuizImage;
+
 @Entity
-@Table(name = "quizzes")
+@Table(name = "quiz_information")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -16,14 +18,36 @@ import java.util.List;
 public class Quiz {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "quizInfoID")
     private Long id;
 
-    @Column(nullable = false)
-    private String title;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contentInfoID", nullable = false)
+    private ContentInformation contentInformation;
 
-    @Column(nullable = false)
-    private String createdByUsername;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "quizType", nullable = false)
+    private QuizType quizType;
+
+    @Column(name = "quiz_detail", columnDefinition = "TEXT", nullable = false)
+    private String quizDetail;
 
     @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<QuizQuestion> questions;
+
+    @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<QuizImage> images;
+
+    @Column(name = "created_at")
+    private java.time.LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private java.time.LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deletedAt;
+
+    public enum QuizType {
+        MULTIPLE_CHOICE, TRUE_FALSE, OPEN_ENDED
+    }
 }

--- a/src/main/java/se499/kayaanbackend/entity/QuizImage.java
+++ b/src/main/java/se499/kayaanbackend/entity/QuizImage.java
@@ -1,0 +1,36 @@
+package se499.kayaanbackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "quiz_image")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuizImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "imageID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quizInfoID", nullable = false)
+    private Quiz quiz;
+
+    @Column(name = "imageURL", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/se499/kayaanbackend/entity/QuizQuestion.java
+++ b/src/main/java/se499/kayaanbackend/entity/QuizQuestion.java
@@ -7,7 +7,7 @@ import lombok.*;
 import java.util.List;
 
 @Entity
-@Table(name = "questions")
+@Table(name = "quiz_question_information")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -23,42 +23,38 @@ public class QuizQuestion {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "questionID")
     private Long id;
 
     // Link back to parent quiz
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "quiz_id", nullable = false)
+    @JoinColumn(name = "quizInfoID", nullable = false)
     private Quiz quiz;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(name = "question_text", nullable = false, columnDefinition = "TEXT")
     private String questionText;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(name = "questionType", nullable = false)
     private QuestionType type;
 
     // For MCQ only: store the choices as a list of strings
     // For True/False or Open-Ended, you can leave this empty
-    @ElementCollection
-    @CollectionTable(name = "question_choices", joinColumns = @JoinColumn(name = "question_id"))
-    @Column(name = "choice")
-    private List<String> choices;
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<QuizQuestionChoice> choices;
 
     // For MCQ/TrueFalse: the correct answer (e.g. "A" or "true")
     // For Open-Ended: you could store sample answers or leave blank (depending on your design)
-    @Column(nullable = true, columnDefinition = "TEXT")
+    @Column(name = "correct_answer", columnDefinition = "TEXT")
     private String correctAnswer;
 
     // Optional metadata: subject, difficulty (you can expand these into enums if you want)
-    @Column(nullable = true)
-    private String subject;
+    @Column(name = "created_at")
+    private java.time.LocalDateTime createdAt;
 
-    @Column(nullable = true)
-    private String difficulty;
+    @Column(name = "updated_at")
+    private java.time.LocalDateTime updatedAt;
 
-    // Tags as a simple list of strings (e.g. ["algebra","easy"])
-    @ElementCollection
-    @CollectionTable(name = "question_tags", joinColumns = @JoinColumn(name = "question_id"))
-    @Column(name = "tag")
-    private List<String> tags;
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deletedAt;
 }

--- a/src/main/java/se499/kayaanbackend/entity/QuizQuestionChoice.java
+++ b/src/main/java/se499/kayaanbackend/entity/QuizQuestionChoice.java
@@ -1,0 +1,36 @@
+package se499.kayaanbackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "quiz_question_choice")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuizQuestionChoice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "choiceID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "questionID", nullable = false)
+    private QuizQuestion question;
+
+    @Column(name = "choiceDetail", columnDefinition = "TEXT", nullable = false)
+    private String choiceDetail;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/se499/kayaanbackend/repository/ContentInformationRepository.java
+++ b/src/main/java/se499/kayaanbackend/repository/ContentInformationRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.entity.ContentInformation;
+
+public interface ContentInformationRepository extends JpaRepository<ContentInformation, Long> {
+}

--- a/src/main/java/se499/kayaanbackend/repository/FlashcardImageRepository.java
+++ b/src/main/java/se499/kayaanbackend/repository/FlashcardImageRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.entity.FlashcardImage;
+
+public interface FlashcardImageRepository extends JpaRepository<FlashcardImage, Long> {
+}

--- a/src/main/java/se499/kayaanbackend/repository/FlashcardRepository.java
+++ b/src/main/java/se499/kayaanbackend/repository/FlashcardRepository.java
@@ -6,5 +6,5 @@ import se499.kayaanbackend.entity.Flashcard;
 import java.util.List;
 
 public interface FlashcardRepository extends JpaRepository<Flashcard, Long> {
-    List<Flashcard> findByCreatedByUsername(String username);
+    List<Flashcard> findByContentInformation_User_Username(String username);
 }

--- a/src/main/java/se499/kayaanbackend/repository/NoteImageRepository.java
+++ b/src/main/java/se499/kayaanbackend/repository/NoteImageRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.entity.NoteImage;
+
+public interface NoteImageRepository extends JpaRepository<NoteImage, Long> {
+}

--- a/src/main/java/se499/kayaanbackend/repository/NoteRepository.java
+++ b/src/main/java/se499/kayaanbackend/repository/NoteRepository.java
@@ -6,5 +6,5 @@ import se499.kayaanbackend.entity.Note;
 import java.util.List;
 
 public interface NoteRepository extends JpaRepository<Note, Long> {
-    List<Note> findByCreatedByUsername(String username);
+    List<Note> findByContentInformation_User_Username(String username);
 }

--- a/src/main/java/se499/kayaanbackend/repository/QuizImageRepository.java
+++ b/src/main/java/se499/kayaanbackend/repository/QuizImageRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.entity.QuizImage;
+
+public interface QuizImageRepository extends JpaRepository<QuizImage, Long> {
+}

--- a/src/main/java/se499/kayaanbackend/repository/QuizQuestionChoiceRepository.java
+++ b/src/main/java/se499/kayaanbackend/repository/QuizQuestionChoiceRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.entity.QuizQuestionChoice;
+
+public interface QuizQuestionChoiceRepository extends JpaRepository<QuizQuestionChoice, Long> {
+}

--- a/src/main/java/se499/kayaanbackend/repository/QuizRepository.java
+++ b/src/main/java/se499/kayaanbackend/repository/QuizRepository.java
@@ -6,5 +6,5 @@ import se499.kayaanbackend.entity.Quiz;
 import java.util.List;
 
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
-    List<Quiz> findByCreatedByUsername(String username);
+    List<Quiz> findByContentInformation_User_Username(String username);
 }

--- a/src/main/java/se499/kayaanbackend/service/FlashcardServiceImpl.java
+++ b/src/main/java/se499/kayaanbackend/service/FlashcardServiceImpl.java
@@ -6,8 +6,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import se499.kayaanbackend.DTO.FlashcardRequestDTO;
 import se499.kayaanbackend.DTO.FlashcardResponseDTO;
+import se499.kayaanbackend.entity.ContentInformation;
 import se499.kayaanbackend.entity.Flashcard;
+import se499.kayaanbackend.repository.ContentInformationRepository;
 import se499.kayaanbackend.repository.FlashcardRepository;
+import se499.kayaanbackend.security.user.UserService;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,43 +20,59 @@ import java.util.stream.Collectors;
 @Transactional
 public class FlashcardServiceImpl implements FlashcardService {
     private final FlashcardRepository flashcardRepository;
+    private final ContentInformationRepository contentInformationRepository;
+    private final UserService userService;
 
     @Override
     public FlashcardResponseDTO createFlashcard(FlashcardRequestDTO dto, String username) {
+        var user = userService.findByUsername(username);
+
+        ContentInformation content = ContentInformation.builder()
+                .contentType(ContentInformation.ContentType.FLASHCARD)
+                .contentSubject(dto.getSubject())
+                .contentTitle(dto.getFrontText())
+                .tag(dto.getTags() != null && !dto.getTags().isEmpty() ? dto.getTags().get(0) : null)
+                .difficulty(ContentInformation.Difficulty.valueOf(dto.getDifficulty().toUpperCase()))
+                .user(user)
+                .createdAt(java.time.LocalDateTime.now())
+                .updatedAt(java.time.LocalDateTime.now())
+                .build();
+
+        content = contentInformationRepository.save(content);
+
         Flashcard card = Flashcard.builder()
                 .frontText(dto.getFrontText())
                 .backText(dto.getBackText())
-                .subject(dto.getSubject())
-                .difficulty(dto.getDifficulty())
-                .tags(dto.getTags())
-                .createdByUsername(username)
+                .contentInformation(content)
+                .createdAt(java.time.LocalDateTime.now())
+                .updatedAt(java.time.LocalDateTime.now())
                 .build();
 
         Flashcard saved = flashcardRepository.save(card);
         return FlashcardResponseDTO.builder()
                 .id(saved.getId())
-                .createdByUsername(saved.getCreatedByUsername())
+                .createdByUsername(username)
                 .frontText(saved.getFrontText())
                 .backText(saved.getBackText())
-                .subject(saved.getSubject())
-                .difficulty(saved.getDifficulty())
-                .tags(saved.getTags())
+                .subject(content.getContentSubject())
+                .difficulty(content.getDifficulty().name())
+                .tags(content.getTag() == null ? null : java.util.List.of(content.getTag()))
                 .build();
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<FlashcardResponseDTO> getAllFlashcardsForUser(String username) {
-        return flashcardRepository.findByCreatedByUsername(username)
+        return flashcardRepository.findByContentInformation_User_Username(username)
                 .stream()
                 .map(f -> FlashcardResponseDTO.builder()
                         .id(f.getId())
-                        .createdByUsername(f.getCreatedByUsername())
+                        .createdByUsername(username)
                         .frontText(f.getFrontText())
                         .backText(f.getBackText())
-                        .subject(f.getSubject())
-                        .difficulty(f.getDifficulty())
-                        .tags(f.getTags())
+                        .subject(f.getContentInformation().getContentSubject())
+                        .difficulty(f.getContentInformation().getDifficulty().name())
+                        .tags(f.getContentInformation().getTag() == null ? null : java.util.List.of(f.getContentInformation().getTag()))
                         .build())
                 .collect(Collectors.toList());
     }
@@ -63,17 +82,17 @@ public class FlashcardServiceImpl implements FlashcardService {
     public FlashcardResponseDTO getFlashcardById(Long id, String username) {
         Flashcard card = flashcardRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Flashcard not found: " + id));
-        if (!card.getCreatedByUsername().equals(username)) {
+        if (!card.getContentInformation().getUser().getUsername().equals(username)) {
             throw new SecurityException("Not authorized");
         }
         return FlashcardResponseDTO.builder()
                 .id(card.getId())
-                .createdByUsername(card.getCreatedByUsername())
+                .createdByUsername(username)
                 .frontText(card.getFrontText())
                 .backText(card.getBackText())
-                .subject(card.getSubject())
-                .difficulty(card.getDifficulty())
-                .tags(card.getTags())
+                .subject(card.getContentInformation().getContentSubject())
+                .difficulty(card.getContentInformation().getDifficulty().name())
+                .tags(card.getContentInformation().getTag() == null ? null : java.util.List.of(card.getContentInformation().getTag()))
                 .build();
     }
 
@@ -81,7 +100,7 @@ public class FlashcardServiceImpl implements FlashcardService {
     public void deleteFlashcard(Long id, String username) {
         Flashcard card = flashcardRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Flashcard not found: " + id));
-        if (!card.getCreatedByUsername().equals(username)) {
+        if (!card.getContentInformation().getUser().getUsername().equals(username)) {
             throw new SecurityException("Not authorized");
         }
         flashcardRepository.delete(card);


### PR DESCRIPTION
## Summary
- add dedicated image entities for notes, flashcards and quizzes
- update `Flashcard`, `Note` and `Quiz` with image relationships
- create repositories for the new image tables

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596c6f4dc883288fd1bc706ef6b3d9