### PR TITLE
Add dedicated image entities

### DIFF
--- a/src/main/java/se499/kayaanbackend/redesign/entity/ContentInformation.java
+++ b/src/main/java/se499/kayaanbackend/redesign/entity/ContentInformation.java
@@ -1,0 +1,47 @@
+package se499.kayaanbackend.redesign.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "content_information")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ContentInformation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer contentInfoID;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ContentType contentType;
+
+    @Column(nullable = false)
+    private String contentSubject;
+
+    @Column(nullable = false)
+    private String contentTitle;
+
+    @Column(nullable = false)
+    private String tag;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Difficulty difficulty;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userID", nullable = false)
+    private UserNew user;
+
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+    private LocalDateTime deleted_at;
+
+    public enum ContentType { Quiz, Flashcard, Note }
+    public enum Difficulty { Easy, Medium, Hard }
+}

--- a/src/main/java/se499/kayaanbackend/redesign/entity/FlashcardImage.java
+++ b/src/main/java/se499/kayaanbackend/redesign/entity/FlashcardImage.java
@@ -1,0 +1,30 @@
+package se499.kayaanbackend.redesign.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "flashcard_image")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FlashcardImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer imageID;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "flashcardID", nullable = false)
+    private FlashcardInfo flashcardInfo;
+
+    @Column(nullable = false)
+    private String imageURL;
+
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+    private LocalDateTime deleted_at;
+}

--- a/src/main/java/se499/kayaanbackend/redesign/entity/FlashcardInfo.java
+++ b/src/main/java/se499/kayaanbackend/redesign/entity/FlashcardInfo.java
@@ -1,0 +1,33 @@
+package se499.kayaanbackend.redesign.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "flashcard_info")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FlashcardInfo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer flashcardID;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contentInfoID", nullable = false)
+    private ContentInformation contentInformation;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String flashcardDetail;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String flashcardAnswer;
+
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+    private LocalDateTime deleted_at;
+}

--- a/src/main/java/se499/kayaanbackend/redesign/entity/GroupContent.java
+++ b/src/main/java/se499/kayaanbackend/redesign/entity/GroupContent.java
@@ -1,0 +1,23 @@
+package se499.kayaanbackend.redesign.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "group_content")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@IdClass(GroupContentId.class)
+public class GroupContent {
+    @Id
+    private Integer groupID;
+    @Id
+    private Integer contentInfoID;
+
+    private LocalDateTime shared_at;
+}

--- a/src/main/java/se499/kayaanbackend/redesign/entity/GroupContentId.java
+++ b/src/main/java/se499/kayaanbackend/redesign/entity/GroupContentId.java
@@ -1,0 +1,11 @@
+package se499.kayaanbackend.redesign.entity;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class GroupContentId implements Serializable {
+    private Integer groupID;
+    private Integer contentInfoID;
+}

--- a/src/main/java/se499/kayaanbackend/redesign/entity/GroupMember.java
+++ b/src/main/java/se499/kayaanbackend/redesign/entity/GroupMember.java
@@ -1,0 +1,29 @@
+package se499.kayaanbackend.redesign.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "group_member")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@IdClass(GroupMemberId.class)
+public class GroupMember {
+    @Id
+    private Integer groupID;
+    @Id
+    private Integer userID;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role = Role.member;
+
+    private LocalDateTime joined_at;
+
+    public enum Role { member, admin }
+}

--- a/src/main/java/se499/kayaanbackend/redesign/entity/GroupMemberId.java
+++ b/src/main/java/se499/kayaanbackend/redesign/entity/GroupMemberId.java
@@ -1,0 +1,11 @@
+package se499.kayaanbackend.redesign.entity;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class GroupMemberId implements Serializable {
+    private Integer groupID;
+    private Integer userID;
+}

--- a/src/main/java/se499/kayaanbackend/redesign/entity/NoteImage.java
+++ b/src/main/java/se499/kayaanbackend/redesign/entity/NoteImage.java
@@ -1,0 +1,30 @@
+package se499.kayaanbackend.redesign.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "note_image")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NoteImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer imageID;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "noteID", nullable = false)
+    private NoteInformation noteInformation;
+
+    @Column(nullable = false)
+    private String imageURL;
+
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+    private LocalDateTime deleted_at;
+}

--- a/src/main/java/se499/kayaanbackend/redesign/entity/NoteInformation.java
+++ b/src/main/java/se499/kayaanbackend/redesign/entity/NoteInformation.java
@@ -1,0 +1,30 @@
+package se499.kayaanbackend.redesign.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "note_information")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NoteInformation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer noteID;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contentInfoID", nullable = false)
+    private ContentInformation contentInformation;
+
+    @Column(name = "note_text", columnDefinition = "LONGTEXT")
+    private String noteText;
+
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+    private LocalDateTime deleted_at;
+}

--- a/src/main/java/se499/kayaanbackend/redesign/entity/QuizImage.java
+++ b/src/main/java/se499/kayaanbackend/redesign/entity/QuizImage.java
@@ -1,0 +1,30 @@
+package se499.kayaanbackend.redesign.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "quiz_image")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuizImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer imageID;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quizInfoID", nullable = false)
+    private QuizInformation quizInformation;
+
+    @Column(nullable = false)
+    private String imageURL;
+
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+    private LocalDateTime deleted_at;
+}

--- a/src/main/java/se499/kayaanbackend/redesign/entity/QuizInformation.java
+++ b/src/main/java/se499/kayaanbackend/redesign/entity/QuizInformation.java
@@ -1,0 +1,36 @@
+package se499.kayaanbackend.redesign.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "quiz_information")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuizInformation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer quizInfoID;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contentInfoID", nullable = false)
+    private ContentInformation contentInformation;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private QuizType quizType;
+
+    @Column(name = "quiz_detail", columnDefinition = "TEXT", nullable = false)
+    private String quizDetail;
+
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+    private LocalDateTime deleted_at;
+
+    public enum QuizType { MultipleChoice, TrueFalse, OpenEnded }
+}

--- a/src/main/java/se499/kayaanbackend/redesign/entity/QuizQuestionChoice.java
+++ b/src/main/java/se499/kayaanbackend/redesign/entity/QuizQuestionChoice.java
@@ -1,0 +1,30 @@
+package se499.kayaanbackend.redesign.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "quiz_question_choice")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuizQuestionChoice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer choiceID;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "questionID", nullable = false)
+    private QuizQuestionInformation question;
+
+    @Column(name = "choiceDetail", columnDefinition = "TEXT", nullable = false)
+    private String choiceDetail;
+
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+    private LocalDateTime deleted_at;
+}

--- a/src/main/java/se499/kayaanbackend/redesign/entity/QuizQuestionInformation.java
+++ b/src/main/java/se499/kayaanbackend/redesign/entity/QuizQuestionInformation.java
@@ -1,0 +1,39 @@
+package se499.kayaanbackend.redesign.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "quiz_question_information")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuizQuestionInformation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer questionID;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quizInfoID", nullable = false)
+    private QuizInformation quizInformation;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private QuestionType questionType;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String questionText;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String correctAnswer;
+
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+    private LocalDateTime deleted_at;
+
+    public enum QuestionType { MultipleChoice, TrueFalse, OpenEnded }
+}

--- a/src/main/java/se499/kayaanbackend/redesign/entity/StudyGroup.java
+++ b/src/main/java/se499/kayaanbackend/redesign/entity/StudyGroup.java
@@ -1,0 +1,30 @@
+package se499.kayaanbackend.redesign.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "study_group")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StudyGroup {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer groupID;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ownerUserID", nullable = false)
+    private UserNew owner;
+
+    @Column(nullable = false)
+    private String name;
+
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+    private LocalDateTime deleted_at;
+}

--- a/src/main/java/se499/kayaanbackend/redesign/entity/UserNew.java
+++ b/src/main/java/se499/kayaanbackend/redesign/entity/UserNew.java
@@ -1,0 +1,40 @@
+package se499.kayaanbackend.redesign.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "User")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserNew {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer userID;
+
+    @Column(nullable = false, unique = true)
+    private String userName;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String firstName;
+
+    @Column(nullable = false)
+    private String lastName;
+
+    private String avatarUrl;
+
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+    private LocalDateTime deleted_at;
+}

--- a/src/main/java/se499/kayaanbackend/redesign/repository/ContentInformationRepository.java
+++ b/src/main/java/se499/kayaanbackend/redesign/repository/ContentInformationRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.redesign.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.redesign.entity.ContentInformation;
+
+public interface ContentInformationRepository extends JpaRepository<ContentInformation, Integer> {
+}

--- a/src/main/java/se499/kayaanbackend/redesign/repository/FlashcardImageRepository.java
+++ b/src/main/java/se499/kayaanbackend/redesign/repository/FlashcardImageRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.redesign.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.redesign.entity.FlashcardImage;
+
+public interface FlashcardImageRepository extends JpaRepository<FlashcardImage, Integer> {
+}

--- a/src/main/java/se499/kayaanbackend/redesign/repository/FlashcardInfoRepository.java
+++ b/src/main/java/se499/kayaanbackend/redesign/repository/FlashcardInfoRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.redesign.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.redesign.entity.FlashcardInfo;
+
+public interface FlashcardInfoRepository extends JpaRepository<FlashcardInfo, Integer> {
+}

--- a/src/main/java/se499/kayaanbackend/redesign/repository/GroupContentRepository.java
+++ b/src/main/java/se499/kayaanbackend/redesign/repository/GroupContentRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.redesign.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.redesign.entity.GroupContent;
+
+public interface GroupContentRepository extends JpaRepository<GroupContent, Integer> {
+}

--- a/src/main/java/se499/kayaanbackend/redesign/repository/GroupMemberRepository.java
+++ b/src/main/java/se499/kayaanbackend/redesign/repository/GroupMemberRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.redesign.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.redesign.entity.GroupMember;
+
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Integer> {
+}

--- a/src/main/java/se499/kayaanbackend/redesign/repository/NoteImageRepository.java
+++ b/src/main/java/se499/kayaanbackend/redesign/repository/NoteImageRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.redesign.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.redesign.entity.NoteImage;
+
+public interface NoteImageRepository extends JpaRepository<NoteImage, Integer> {
+}

--- a/src/main/java/se499/kayaanbackend/redesign/repository/NoteInformationRepository.java
+++ b/src/main/java/se499/kayaanbackend/redesign/repository/NoteInformationRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.redesign.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.redesign.entity.NoteInformation;
+
+public interface NoteInformationRepository extends JpaRepository<NoteInformation, Integer> {
+}

--- a/src/main/java/se499/kayaanbackend/redesign/repository/QuizImageRepository.java
+++ b/src/main/java/se499/kayaanbackend/redesign/repository/QuizImageRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.redesign.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.redesign.entity.QuizImage;
+
+public interface QuizImageRepository extends JpaRepository<QuizImage, Integer> {
+}

--- a/src/main/java/se499/kayaanbackend/redesign/repository/QuizInformationRepository.java
+++ b/src/main/java/se499/kayaanbackend/redesign/repository/QuizInformationRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.redesign.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.redesign.entity.QuizInformation;
+
+public interface QuizInformationRepository extends JpaRepository<QuizInformation, Integer> {
+}

--- a/src/main/java/se499/kayaanbackend/redesign/repository/QuizQuestionChoiceRepository.java
+++ b/src/main/java/se499/kayaanbackend/redesign/repository/QuizQuestionChoiceRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.redesign.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.redesign.entity.QuizQuestionChoice;
+
+public interface QuizQuestionChoiceRepository extends JpaRepository<QuizQuestionChoice, Integer> {
+}

--- a/src/main/java/se499/kayaanbackend/redesign/repository/QuizQuestionInformationRepository.java
+++ b/src/main/java/se499/kayaanbackend/redesign/repository/QuizQuestionInformationRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.redesign.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.redesign.entity.QuizQuestionInformation;
+
+public interface QuizQuestionInformationRepository extends JpaRepository<QuizQuestionInformation, Integer> {
+}

--- a/src/main/java/se499/kayaanbackend/redesign/repository/StudyGroupRepository.java
+++ b/src/main/java/se499/kayaanbackend/redesign/repository/StudyGroupRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.redesign.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.redesign.entity.StudyGroup;
+
+public interface StudyGroupRepository extends JpaRepository<StudyGroup, Integer> {
+}

--- a/src/main/java/se499/kayaanbackend/redesign/repository/UserNewRepository.java
+++ b/src/main/java/se499/kayaanbackend/redesign/repository/UserNewRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.redesign.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.redesign.entity.UserNew;
+
+public interface UserNewRepository extends JpaRepository<UserNew, Integer> {
+}


### PR DESCRIPTION
## Summary
- remove generic `ContentImage` entity
- add `NoteImage`, `FlashcardImage`, and `QuizImage` with links to their parent content
- provide repositories for the new image entities

## Testing
- `./mvnw -q test` *(failed to download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_685a6a383ad8832899a9eee4b1701fbb