### PR TITLE
Add content management module

### DIFF
--- a/src/main/java/se499/kayaanbackend/content/controller/ContentController.java
+++ b/src/main/java/se499/kayaanbackend/content/controller/ContentController.java
@@ -1,0 +1,39 @@
+package se499.kayaanbackend.content.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import se499.kayaanbackend.content.dto.ContentDto;
+import se499.kayaanbackend.content.service.ContentInformationService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ContentController {
+
+    private final ContentInformationService contentService;
+
+    @GetMapping("/content/{id}")
+    public ResponseEntity<ContentDto> getContent(@PathVariable Long id) {
+        return ResponseEntity.ok(contentService.getContent(id));
+    }
+
+    @GetMapping("/users/{userId}/contents")
+    public ResponseEntity<List<ContentDto>> getUserContents(@PathVariable Long userId) {
+        return ResponseEntity.ok(contentService.getUserContents(userId));
+    }
+
+    @DeleteMapping("/content/{id}")
+    public ResponseEntity<Void> deleteContent(@PathVariable Long id) {
+        contentService.softDelete(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/content/{id}/restore")
+    public ResponseEntity<Void> restoreContent(@PathVariable Long id) {
+        contentService.restore(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/se499/kayaanbackend/content/controller/FlashcardController.java
+++ b/src/main/java/se499/kayaanbackend/content/controller/FlashcardController.java
@@ -1,0 +1,42 @@
+package se499.kayaanbackend.content.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import se499.kayaanbackend.content.dto.FlashcardDto;
+import se499.kayaanbackend.content.service.FlashcardService;
+
+@RestController
+@RequestMapping("/api/flashcard")
+@RequiredArgsConstructor
+public class FlashcardController {
+
+    private final FlashcardService flashcardService;
+
+    @PostMapping
+    public ResponseEntity<FlashcardDto> createFlashcard(@RequestParam Long userId, @RequestBody FlashcardDto dto) {
+        return ResponseEntity.ok(flashcardService.createFlashcard(userId, dto));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<FlashcardDto> getFlashcard(@PathVariable Long id) {
+        return ResponseEntity.ok(flashcardService.getFlashcard(id));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<FlashcardDto> updateFlashcard(@PathVariable Long id, @RequestBody FlashcardDto dto) {
+        return ResponseEntity.ok(flashcardService.updateFlashcard(id, dto));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteFlashcard(@PathVariable Long id) {
+        flashcardService.deleteFlashcard(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{id}/restore")
+    public ResponseEntity<Void> restoreFlashcard(@PathVariable Long id) {
+        flashcardService.restoreFlashcard(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/se499/kayaanbackend/content/controller/NoteController.java
+++ b/src/main/java/se499/kayaanbackend/content/controller/NoteController.java
@@ -1,0 +1,42 @@
+package se499.kayaanbackend.content.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import se499.kayaanbackend.content.dto.NoteDto;
+import se499.kayaanbackend.content.service.NoteService;
+
+@RestController
+@RequestMapping("/api/notes")
+@RequiredArgsConstructor
+public class NoteController {
+
+    private final NoteService noteService;
+
+    @PostMapping
+    public ResponseEntity<NoteDto> createNote(@RequestParam Long userId, @RequestBody NoteDto dto) {
+        return ResponseEntity.ok(noteService.createNote(userId, dto));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<NoteDto> getNote(@PathVariable Long id) {
+        return ResponseEntity.ok(noteService.getNote(id));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<NoteDto> updateNote(@PathVariable Long id, @RequestBody NoteDto dto) {
+        return ResponseEntity.ok(noteService.updateNote(id, dto));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteNote(@PathVariable Long id) {
+        noteService.deleteNote(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{id}/restore")
+    public ResponseEntity<Void> restoreNote(@PathVariable Long id) {
+        noteService.restoreNote(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/se499/kayaanbackend/content/controller/QuizController.java
+++ b/src/main/java/se499/kayaanbackend/content/controller/QuizController.java
@@ -1,0 +1,42 @@
+package se499.kayaanbackend.content.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import se499.kayaanbackend.content.dto.QuizDto;
+import se499.kayaanbackend.content.service.QuizService;
+
+@RestController
+@RequestMapping("/api/quiz")
+@RequiredArgsConstructor
+public class QuizController {
+
+    private final QuizService quizService;
+
+    @PostMapping
+    public ResponseEntity<QuizDto> createQuiz(@RequestParam Long userId, @RequestBody QuizDto dto) {
+        return ResponseEntity.ok(quizService.createQuiz(userId, dto));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<QuizDto> getQuiz(@PathVariable Long id) {
+        return ResponseEntity.ok(quizService.getQuiz(id));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<QuizDto> updateQuiz(@PathVariable Long id, @RequestBody QuizDto dto) {
+        return ResponseEntity.ok(quizService.updateQuiz(id, dto));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteQuiz(@PathVariable Long id) {
+        quizService.deleteQuiz(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{id}/restore")
+    public ResponseEntity<Void> restoreQuiz(@PathVariable Long id) {
+        quizService.restoreQuiz(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/se499/kayaanbackend/content/dto/ContentDto.java
+++ b/src/main/java/se499/kayaanbackend/content/dto/ContentDto.java
@@ -1,0 +1,16 @@
+package se499.kayaanbackend.content.dto;
+
+import lombok.Data;
+import se499.kayaanbackend.content.enums.ContentType;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ContentDto {
+    private Long contentId;
+    private Long userId;
+    private ContentType contentType;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/se499/kayaanbackend/content/dto/FlashcardDto.java
+++ b/src/main/java/se499/kayaanbackend/content/dto/FlashcardDto.java
@@ -1,0 +1,12 @@
+package se499.kayaanbackend.content.dto;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class FlashcardDto {
+    private Long flashcardId;
+    private Long contentId;
+    private String title;
+    private List<FlashcardImageDto> images;
+}

--- a/src/main/java/se499/kayaanbackend/content/dto/FlashcardImageDto.java
+++ b/src/main/java/se499/kayaanbackend/content/dto/FlashcardImageDto.java
@@ -1,0 +1,9 @@
+package se499.kayaanbackend.content.dto;
+
+import lombok.Data;
+
+@Data
+public class FlashcardImageDto {
+    private Long imageId;
+    private String imageUrl;
+}

--- a/src/main/java/se499/kayaanbackend/content/dto/NoteDto.java
+++ b/src/main/java/se499/kayaanbackend/content/dto/NoteDto.java
@@ -1,0 +1,12 @@
+package se499.kayaanbackend.content.dto;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class NoteDto {
+    private Long noteId;
+    private Long contentId;
+    private String noteTitle;
+    private List<NoteImageDto> images;
+}

--- a/src/main/java/se499/kayaanbackend/content/dto/NoteImageDto.java
+++ b/src/main/java/se499/kayaanbackend/content/dto/NoteImageDto.java
@@ -1,0 +1,9 @@
+package se499.kayaanbackend.content.dto;
+
+import lombok.Data;
+
+@Data
+public class NoteImageDto {
+    private Long imageId;
+    private String imageUrl;
+}

--- a/src/main/java/se499/kayaanbackend/content/dto/QuizChoiceDto.java
+++ b/src/main/java/se499/kayaanbackend/content/dto/QuizChoiceDto.java
@@ -1,0 +1,9 @@
+package se499.kayaanbackend.content.dto;
+
+import lombok.Data;
+
+@Data
+public class QuizChoiceDto {
+    private Long choiceId;
+    private String choiceDetail;
+}

--- a/src/main/java/se499/kayaanbackend/content/dto/QuizDto.java
+++ b/src/main/java/se499/kayaanbackend/content/dto/QuizDto.java
@@ -1,0 +1,12 @@
+package se499.kayaanbackend.content.dto;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class QuizDto {
+    private Long quizId;
+    private Long contentId;
+    private String title;
+    private List<QuizQuestionDto> questions;
+}

--- a/src/main/java/se499/kayaanbackend/content/dto/QuizQuestionDto.java
+++ b/src/main/java/se499/kayaanbackend/content/dto/QuizQuestionDto.java
@@ -1,0 +1,11 @@
+package se499.kayaanbackend.content.dto;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class QuizQuestionDto {
+    private Long questionId;
+    private String questionText;
+    private List<QuizChoiceDto> choices;
+}

--- a/src/main/java/se499/kayaanbackend/content/entity/ContentInformation.java
+++ b/src/main/java/se499/kayaanbackend/content/entity/ContentInformation.java
@@ -1,0 +1,48 @@
+package se499.kayaanbackend.content.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import se499.kayaanbackend.content.enums.ContentType;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "content_information")
+public class ContentInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "content_id")
+    private Long contentId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "content_type", nullable = false, length = 20)
+    private ContentType contentType;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    public void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/se499/kayaanbackend/content/entity/FlashcardImage.java
+++ b/src/main/java/se499/kayaanbackend/content/entity/FlashcardImage.java
@@ -1,0 +1,47 @@
+package se499.kayaanbackend.content.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "flashcard_image")
+public class FlashcardImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long imageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "flashcard_id", nullable = false)
+    private FlashcardInformation flashcard;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    public void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/se499/kayaanbackend/content/entity/FlashcardInformation.java
+++ b/src/main/java/se499/kayaanbackend/content/entity/FlashcardInformation.java
@@ -1,0 +1,52 @@
+package se499.kayaanbackend.content.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "flashcard_information")
+public class FlashcardInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "flashcard_id")
+    private Long flashcardId;
+
+    @OneToOne
+    @JoinColumn(name = "content_id", nullable = false)
+    private ContentInformation contentInformation;
+
+    @Column(nullable = false)
+    private String title;
+
+    @OneToMany(mappedBy = "flashcard", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FlashcardImage> images = new ArrayList<>();
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    public void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/se499/kayaanbackend/content/entity/NoteImage.java
+++ b/src/main/java/se499/kayaanbackend/content/entity/NoteImage.java
@@ -1,0 +1,47 @@
+package se499.kayaanbackend.content.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "note_image")
+public class NoteImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long imageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "note_id", nullable = false)
+    private NoteInformation note;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    public void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/se499/kayaanbackend/content/entity/NoteInformation.java
+++ b/src/main/java/se499/kayaanbackend/content/entity/NoteInformation.java
@@ -1,0 +1,52 @@
+package se499.kayaanbackend.content.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "note_information")
+public class NoteInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "note_id")
+    private Long noteId;
+
+    @OneToOne
+    @JoinColumn(name = "content_id", nullable = false)
+    private ContentInformation contentInformation;
+
+    @Column(name = "note_title", nullable = false)
+    private String noteTitle;
+
+    @OneToMany(mappedBy = "note", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<NoteImage> images = new ArrayList<>();
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    public void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/se499/kayaanbackend/content/entity/QuizInformation.java
+++ b/src/main/java/se499/kayaanbackend/content/entity/QuizInformation.java
@@ -1,0 +1,52 @@
+package se499.kayaanbackend.content.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "quiz_information")
+public class QuizInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "quiz_id")
+    private Long quizId;
+
+    @OneToOne
+    @JoinColumn(name = "content_id", nullable = false)
+    private ContentInformation contentInformation;
+
+    @Column(nullable = false)
+    private String title;
+
+    @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<QuizQuestionInformation> questions = new ArrayList<>();
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    public void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/se499/kayaanbackend/content/entity/QuizQuestionChoice.java
+++ b/src/main/java/se499/kayaanbackend/content/entity/QuizQuestionChoice.java
@@ -1,0 +1,47 @@
+package se499.kayaanbackend.content.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "quiz_question_choice")
+public class QuizQuestionChoice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "choice_id")
+    private Long choiceId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    private QuizQuestionInformation question;
+
+    @Column(name = "choice_detail", nullable = false)
+    private String choiceDetail;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    public void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/se499/kayaanbackend/content/entity/QuizQuestionInformation.java
+++ b/src/main/java/se499/kayaanbackend/content/entity/QuizQuestionInformation.java
@@ -1,0 +1,52 @@
+package se499.kayaanbackend.content.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "quiz_question_information")
+public class QuizQuestionInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "question_id")
+    private Long questionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_id", nullable = false)
+    private QuizInformation quiz;
+
+    @Column(name = "question_text", nullable = false)
+    private String questionText;
+
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<QuizQuestionChoice> choices = new ArrayList<>();
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    public void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/se499/kayaanbackend/content/enums/ContentType.java
+++ b/src/main/java/se499/kayaanbackend/content/enums/ContentType.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.content.enums;
+
+public enum ContentType {
+    QUIZ,
+    NOTE,
+    FLASHCARD
+}

--- a/src/main/java/se499/kayaanbackend/content/repository/ContentInformationRepository.java
+++ b/src/main/java/se499/kayaanbackend/content/repository/ContentInformationRepository.java
@@ -1,0 +1,10 @@
+package se499.kayaanbackend.content.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.content.entity.ContentInformation;
+
+import java.util.List;
+
+public interface ContentInformationRepository extends JpaRepository<ContentInformation, Long> {
+    List<ContentInformation> findByUserIdAndDeletedAtIsNull(Long userId);
+}

--- a/src/main/java/se499/kayaanbackend/content/repository/FlashcardImageRepository.java
+++ b/src/main/java/se499/kayaanbackend/content/repository/FlashcardImageRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.content.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.content.entity.FlashcardImage;
+
+public interface FlashcardImageRepository extends JpaRepository<FlashcardImage, Long> {
+}

--- a/src/main/java/se499/kayaanbackend/content/repository/FlashcardInformationRepository.java
+++ b/src/main/java/se499/kayaanbackend/content/repository/FlashcardInformationRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.content.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.content.entity.FlashcardInformation;
+
+public interface FlashcardInformationRepository extends JpaRepository<FlashcardInformation, Long> {
+}

--- a/src/main/java/se499/kayaanbackend/content/repository/NoteImageRepository.java
+++ b/src/main/java/se499/kayaanbackend/content/repository/NoteImageRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.content.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.content.entity.NoteImage;
+
+public interface NoteImageRepository extends JpaRepository<NoteImage, Long> {
+}

--- a/src/main/java/se499/kayaanbackend/content/repository/NoteInformationRepository.java
+++ b/src/main/java/se499/kayaanbackend/content/repository/NoteInformationRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.content.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.content.entity.NoteInformation;
+
+public interface NoteInformationRepository extends JpaRepository<NoteInformation, Long> {
+}

--- a/src/main/java/se499/kayaanbackend/content/repository/QuizInformationRepository.java
+++ b/src/main/java/se499/kayaanbackend/content/repository/QuizInformationRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.content.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.content.entity.QuizInformation;
+
+public interface QuizInformationRepository extends JpaRepository<QuizInformation, Long> {
+}

--- a/src/main/java/se499/kayaanbackend/content/repository/QuizQuestionChoiceRepository.java
+++ b/src/main/java/se499/kayaanbackend/content/repository/QuizQuestionChoiceRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.content.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.content.entity.QuizQuestionChoice;
+
+public interface QuizQuestionChoiceRepository extends JpaRepository<QuizQuestionChoice, Long> {
+}

--- a/src/main/java/se499/kayaanbackend/content/repository/QuizQuestionInformationRepository.java
+++ b/src/main/java/se499/kayaanbackend/content/repository/QuizQuestionInformationRepository.java
@@ -1,0 +1,7 @@
+package se499.kayaanbackend.content.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se499.kayaanbackend.content.entity.QuizQuestionInformation;
+
+public interface QuizQuestionInformationRepository extends JpaRepository<QuizQuestionInformation, Long> {
+}

--- a/src/main/java/se499/kayaanbackend/content/service/ContentInformationService.java
+++ b/src/main/java/se499/kayaanbackend/content/service/ContentInformationService.java
@@ -1,0 +1,12 @@
+package se499.kayaanbackend.content.service;
+
+import se499.kayaanbackend.content.dto.ContentDto;
+
+import java.util.List;
+
+public interface ContentInformationService {
+    ContentDto getContent(Long id);
+    List<ContentDto> getUserContents(Long userId);
+    void softDelete(Long id);
+    void restore(Long id);
+}

--- a/src/main/java/se499/kayaanbackend/content/service/ContentInformationServiceImpl.java
+++ b/src/main/java/se499/kayaanbackend/content/service/ContentInformationServiceImpl.java
@@ -1,0 +1,64 @@
+package se499.kayaanbackend.content.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import se499.kayaanbackend.content.dto.ContentDto;
+import se499.kayaanbackend.content.entity.ContentInformation;
+import se499.kayaanbackend.content.repository.ContentInformationRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ContentInformationServiceImpl implements ContentInformationService {
+
+    private final ContentInformationRepository repository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public ContentDto getContent(Long id) {
+        ContentInformation entity = repository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Content not found"));
+        return toDto(entity);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ContentDto> getUserContents(Long userId) {
+        return repository.findByUserIdAndDeletedAtIsNull(userId)
+                .stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void softDelete(Long id) {
+        ContentInformation entity = repository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Content not found"));
+        entity.setDeletedAt(LocalDateTime.now());
+        repository.save(entity);
+    }
+
+    @Override
+    public void restore(Long id) {
+        ContentInformation entity = repository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Content not found"));
+        entity.setDeletedAt(null);
+        repository.save(entity);
+    }
+
+    private ContentDto toDto(ContentInformation entity) {
+        ContentDto dto = new ContentDto();
+        dto.setContentId(entity.getContentId());
+        dto.setUserId(entity.getUserId());
+        dto.setContentType(entity.getContentType());
+        dto.setCreatedAt(entity.getCreatedAt());
+        dto.setUpdatedAt(entity.getUpdatedAt());
+        dto.setDeletedAt(entity.getDeletedAt());
+        return dto;
+    }
+}

--- a/src/main/java/se499/kayaanbackend/content/service/FlashcardService.java
+++ b/src/main/java/se499/kayaanbackend/content/service/FlashcardService.java
@@ -1,0 +1,11 @@
+package se499.kayaanbackend.content.service;
+
+import se499.kayaanbackend.content.dto.FlashcardDto;
+
+public interface FlashcardService {
+    FlashcardDto createFlashcard(Long userId, FlashcardDto dto);
+    FlashcardDto getFlashcard(Long id);
+    FlashcardDto updateFlashcard(Long id, FlashcardDto dto);
+    void deleteFlashcard(Long id);
+    void restoreFlashcard(Long id);
+}

--- a/src/main/java/se499/kayaanbackend/content/service/FlashcardServiceImpl.java
+++ b/src/main/java/se499/kayaanbackend/content/service/FlashcardServiceImpl.java
@@ -1,0 +1,114 @@
+package se499.kayaanbackend.content.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import se499.kayaanbackend.content.dto.FlashcardDto;
+import se499.kayaanbackend.content.dto.FlashcardImageDto;
+import se499.kayaanbackend.content.entity.ContentInformation;
+import se499.kayaanbackend.content.entity.FlashcardImage;
+import se499.kayaanbackend.content.entity.FlashcardInformation;
+import se499.kayaanbackend.content.enums.ContentType;
+import se499.kayaanbackend.content.repository.ContentInformationRepository;
+import se499.kayaanbackend.content.repository.FlashcardInformationRepository;
+
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FlashcardServiceImpl implements FlashcardService {
+
+    private final ContentInformationRepository contentRepository;
+    private final FlashcardInformationRepository flashcardRepository;
+
+    @Override
+    public FlashcardDto createFlashcard(Long userId, FlashcardDto dto) {
+        ContentInformation content = ContentInformation.builder()
+                .userId(userId)
+                .contentType(ContentType.FLASHCARD)
+                .build();
+        contentRepository.save(content);
+
+        FlashcardInformation flashcard = FlashcardInformation.builder()
+                .contentInformation(content)
+                .title(dto.getTitle())
+                .build();
+
+        if (dto.getImages() != null) {
+            flashcard.setImages(dto.getImages().stream()
+                    .map(i -> FlashcardImage.builder()
+                            .flashcard(flashcard)
+                            .imageUrl(i.getImageUrl())
+                            .build())
+                    .collect(Collectors.toList()));
+        }
+
+        FlashcardInformation saved = flashcardRepository.save(flashcard);
+        dto.setFlashcardId(saved.getFlashcardId());
+        dto.setContentId(content.getContentId());
+        return dto;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public FlashcardDto getFlashcard(Long id) {
+        FlashcardInformation flashcard = flashcardRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Flashcard not found"));
+        return toDto(flashcard);
+    }
+
+    @Override
+    public FlashcardDto updateFlashcard(Long id, FlashcardDto dto) {
+        FlashcardInformation flashcard = flashcardRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Flashcard not found"));
+        flashcard.setTitle(dto.getTitle());
+        flashcard.getImages().clear();
+        if (dto.getImages() != null) {
+            flashcard.getImages().addAll(dto.getImages().stream()
+                    .map(i -> FlashcardImage.builder()
+                            .flashcard(flashcard)
+                            .imageUrl(i.getImageUrl())
+                            .build())
+                    .collect(Collectors.toList()));
+        }
+        return toDto(flashcardRepository.save(flashcard));
+    }
+
+    @Override
+    public void deleteFlashcard(Long id) {
+        FlashcardInformation flashcard = flashcardRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Flashcard not found"));
+        LocalDateTime now = LocalDateTime.now();
+        flashcard.setDeletedAt(now);
+        flashcard.getContentInformation().setDeletedAt(now);
+        flashcardRepository.save(flashcard);
+    }
+
+    @Override
+    public void restoreFlashcard(Long id) {
+        FlashcardInformation flashcard = flashcardRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Flashcard not found"));
+        flashcard.setDeletedAt(null);
+        flashcard.getContentInformation().setDeletedAt(null);
+        flashcardRepository.save(flashcard);
+    }
+
+    private FlashcardDto toDto(FlashcardInformation flashcard) {
+        FlashcardDto dto = new FlashcardDto();
+        dto.setFlashcardId(flashcard.getFlashcardId());
+        dto.setContentId(flashcard.getContentInformation().getContentId());
+        dto.setTitle(flashcard.getTitle());
+        dto.setImages(
+                flashcard.getImages().stream()
+                        .map(i -> {
+                            FlashcardImageDto idto = new FlashcardImageDto();
+                            idto.setImageId(i.getImageId());
+                            idto.setImageUrl(i.getImageUrl());
+                            return idto;
+                        }).collect(Collectors.toList())
+        );
+        return dto;
+    }
+}

--- a/src/main/java/se499/kayaanbackend/content/service/NoteService.java
+++ b/src/main/java/se499/kayaanbackend/content/service/NoteService.java
@@ -1,0 +1,11 @@
+package se499.kayaanbackend.content.service;
+
+import se499.kayaanbackend.content.dto.NoteDto;
+
+public interface NoteService {
+    NoteDto createNote(Long userId, NoteDto dto);
+    NoteDto getNote(Long id);
+    NoteDto updateNote(Long id, NoteDto dto);
+    void deleteNote(Long id);
+    void restoreNote(Long id);
+}

--- a/src/main/java/se499/kayaanbackend/content/service/NoteServiceImpl.java
+++ b/src/main/java/se499/kayaanbackend/content/service/NoteServiceImpl.java
@@ -1,0 +1,114 @@
+package se499.kayaanbackend.content.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import se499.kayaanbackend.content.dto.NoteDto;
+import se499.kayaanbackend.content.dto.NoteImageDto;
+import se499.kayaanbackend.content.entity.ContentInformation;
+import se499.kayaanbackend.content.entity.NoteImage;
+import se499.kayaanbackend.content.entity.NoteInformation;
+import se499.kayaanbackend.content.enums.ContentType;
+import se499.kayaanbackend.content.repository.ContentInformationRepository;
+import se499.kayaanbackend.content.repository.NoteInformationRepository;
+
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NoteServiceImpl implements NoteService {
+
+    private final ContentInformationRepository contentRepository;
+    private final NoteInformationRepository noteRepository;
+
+    @Override
+    public NoteDto createNote(Long userId, NoteDto dto) {
+        ContentInformation content = ContentInformation.builder()
+                .userId(userId)
+                .contentType(ContentType.NOTE)
+                .build();
+        contentRepository.save(content);
+
+        NoteInformation note = NoteInformation.builder()
+                .contentInformation(content)
+                .noteTitle(dto.getNoteTitle())
+                .build();
+
+        if (dto.getImages() != null) {
+            note.setImages(dto.getImages().stream()
+                    .map(i -> NoteImage.builder()
+                            .note(note)
+                            .imageUrl(i.getImageUrl())
+                            .build())
+                    .collect(Collectors.toList()));
+        }
+
+        NoteInformation saved = noteRepository.save(note);
+        dto.setNoteId(saved.getNoteId());
+        dto.setContentId(content.getContentId());
+        return dto;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public NoteDto getNote(Long id) {
+        NoteInformation note = noteRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Note not found"));
+        return toDto(note);
+    }
+
+    @Override
+    public NoteDto updateNote(Long id, NoteDto dto) {
+        NoteInformation note = noteRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Note not found"));
+        note.setNoteTitle(dto.getNoteTitle());
+        note.getImages().clear();
+        if (dto.getImages() != null) {
+            note.getImages().addAll(dto.getImages().stream()
+                    .map(i -> NoteImage.builder()
+                            .note(note)
+                            .imageUrl(i.getImageUrl())
+                            .build())
+                    .collect(Collectors.toList()));
+        }
+        return toDto(noteRepository.save(note));
+    }
+
+    @Override
+    public void deleteNote(Long id) {
+        NoteInformation note = noteRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Note not found"));
+        LocalDateTime now = LocalDateTime.now();
+        note.setDeletedAt(now);
+        note.getContentInformation().setDeletedAt(now);
+        noteRepository.save(note);
+    }
+
+    @Override
+    public void restoreNote(Long id) {
+        NoteInformation note = noteRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Note not found"));
+        note.setDeletedAt(null);
+        note.getContentInformation().setDeletedAt(null);
+        noteRepository.save(note);
+    }
+
+    private NoteDto toDto(NoteInformation note) {
+        NoteDto dto = new NoteDto();
+        dto.setNoteId(note.getNoteId());
+        dto.setContentId(note.getContentInformation().getContentId());
+        dto.setNoteTitle(note.getNoteTitle());
+        dto.setImages(
+                note.getImages().stream()
+                        .map(i -> {
+                            NoteImageDto idto = new NoteImageDto();
+                            idto.setImageId(i.getImageId());
+                            idto.setImageUrl(i.getImageUrl());
+                            return idto;
+                        }).collect(Collectors.toList())
+        );
+        return dto;
+    }
+}

--- a/src/main/java/se499/kayaanbackend/content/service/QuizService.java
+++ b/src/main/java/se499/kayaanbackend/content/service/QuizService.java
@@ -1,0 +1,11 @@
+package se499.kayaanbackend.content.service;
+
+import se499.kayaanbackend.content.dto.QuizDto;
+
+public interface QuizService {
+    QuizDto createQuiz(Long userId, QuizDto dto);
+    QuizDto getQuiz(Long id);
+    QuizDto updateQuiz(Long id, QuizDto dto);
+    void deleteQuiz(Long id);
+    void restoreQuiz(Long id);
+}

--- a/src/main/java/se499/kayaanbackend/content/service/QuizServiceImpl.java
+++ b/src/main/java/se499/kayaanbackend/content/service/QuizServiceImpl.java
@@ -1,0 +1,132 @@
+package se499.kayaanbackend.content.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import se499.kayaanbackend.content.dto.*;
+import se499.kayaanbackend.content.entity.*;
+import se499.kayaanbackend.content.enums.ContentType;
+import se499.kayaanbackend.content.repository.*;
+
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizServiceImpl implements QuizService {
+
+    private final ContentInformationRepository contentRepository;
+    private final QuizInformationRepository quizRepository;
+
+    @Override
+    public QuizDto createQuiz(Long userId, QuizDto dto) {
+        ContentInformation content = ContentInformation.builder()
+                .userId(userId)
+                .contentType(ContentType.QUIZ)
+                .build();
+        contentRepository.save(content);
+
+        QuizInformation quiz = QuizInformation.builder()
+                .contentInformation(content)
+                .title(dto.getTitle())
+                .build();
+
+        if (dto.getQuestions() != null) {
+            quiz.setQuestions(dto.getQuestions().stream()
+                    .map(q -> toQuestionEntity(q, quiz))
+                    .collect(Collectors.toList()));
+        }
+
+        QuizInformation saved = quizRepository.save(quiz);
+        dto.setQuizId(saved.getQuizId());
+        dto.setContentId(content.getContentId());
+        return dto;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public QuizDto getQuiz(Long id) {
+        QuizInformation quiz = quizRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Quiz not found"));
+        return toDto(quiz);
+    }
+
+    @Override
+    public QuizDto updateQuiz(Long id, QuizDto dto) {
+        QuizInformation quiz = quizRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Quiz not found"));
+        quiz.setTitle(dto.getTitle());
+        quiz.getQuestions().clear();
+        if (dto.getQuestions() != null) {
+            quiz.getQuestions().addAll(
+                    dto.getQuestions().stream()
+                            .map(q -> toQuestionEntity(q, quiz))
+                            .collect(Collectors.toList()));
+        }
+        return toDto(quizRepository.save(quiz));
+    }
+
+    @Override
+    public void deleteQuiz(Long id) {
+        QuizInformation quiz = quizRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Quiz not found"));
+        quiz.setDeletedAt(LocalDateTime.now());
+        quiz.getContentInformation().setDeletedAt(LocalDateTime.now());
+        quizRepository.save(quiz);
+    }
+
+    @Override
+    public void restoreQuiz(Long id) {
+        QuizInformation quiz = quizRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Quiz not found"));
+        quiz.setDeletedAt(null);
+        quiz.getContentInformation().setDeletedAt(null);
+        quizRepository.save(quiz);
+    }
+
+    private QuizDto toDto(QuizInformation quiz) {
+        QuizDto dto = new QuizDto();
+        dto.setQuizId(quiz.getQuizId());
+        dto.setContentId(quiz.getContentInformation().getContentId());
+        dto.setTitle(quiz.getTitle());
+        dto.setQuestions(
+                quiz.getQuestions().stream()
+                        .map(this::toQuestionDto)
+                        .collect(Collectors.toList())
+        );
+        return dto;
+    }
+
+    private QuizQuestionDto toQuestionDto(QuizQuestionInformation question) {
+        QuizQuestionDto dto = new QuizQuestionDto();
+        dto.setQuestionId(question.getQuestionId());
+        dto.setQuestionText(question.getQuestionText());
+        dto.setChoices(
+                question.getChoices().stream()
+                        .map(c -> {
+                            QuizChoiceDto cdto = new QuizChoiceDto();
+                            cdto.setChoiceId(c.getChoiceId());
+                            cdto.setChoiceDetail(c.getChoiceDetail());
+                            return cdto;
+                        }).collect(Collectors.toList())
+        );
+        return dto;
+    }
+
+    private QuizQuestionInformation toQuestionEntity(QuizQuestionDto dto, QuizInformation quiz) {
+        QuizQuestionInformation question = QuizQuestionInformation.builder()
+                .quiz(quiz)
+                .questionText(dto.getQuestionText())
+                .build();
+        if (dto.getChoices() != null) {
+            question.setChoices(dto.getChoices().stream()
+                    .map(c -> QuizQuestionChoice.builder()
+                            .question(question)
+                            .choiceDetail(c.getChoiceDetail())
+                            .build())
+                    .collect(Collectors.toList()));
+        }
+        return question;
+    }
+}


### PR DESCRIPTION
## Summary
- implement Content module according to ER diagram
- add entity, DTO, repository, service, and controller classes
- provide enums and endpoints for quizzes, notes, and flashcards

## Testing
- `mvn -q -DskipTests compile` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602fc018508322a71c399b83e639a5